### PR TITLE
Idlehands/add schema and generate first resource

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -8,7 +8,12 @@
 import Config
 
 config :better_words,
-  ecto_repos: [BetterWords.Repo]
+  ecto_repos: [BetterWords.Repo],
+  generators: [binary_id: true]
+
+config :better_words, BetterWords.Repo,
+  migration_primary_key: [type: :binary_id, autogenerate: true],
+  migration_timestamps: [type: :utc_datetime_usec]
 
 # Configures the endpoint
 config :better_words, BetterWordsWeb.Endpoint,

--- a/lib/better_words/schema.ex
+++ b/lib/better_words/schema.ex
@@ -1,0 +1,16 @@
+defmodule BetterWords.Schema do
+  @moduledoc false
+
+  defmacro __using__(_) do
+    quote do
+      use Ecto.Schema
+      # uncomment this when we want to add common functions
+      # import BetterWords.Schema
+      import Ecto.Changeset
+
+      @primary_key {:id, :binary_id, autogenerate: true}
+      @foreign_key_type :binary_id
+      @timestamps_opts type: :utc_datetime_usec
+    end
+  end
+end

--- a/lib/better_words/words.ex
+++ b/lib/better_words/words.ex
@@ -1,0 +1,104 @@
+defmodule BetterWords.Words do
+  @moduledoc """
+  The Words context.
+  """
+
+  import Ecto.Query, warn: false
+  alias BetterWords.Repo
+
+  alias BetterWords.Words.WorstWord
+
+  @doc """
+  Returns the list of worst_words.
+
+  ## Examples
+
+      iex> list_worst_words()
+      [%WorstWord{}, ...]
+
+  """
+  def list_worst_words do
+    Repo.all(WorstWord)
+  end
+
+  @doc """
+  Gets a single worst_word.
+
+  Raises `Ecto.NoResultsError` if the Worst word does not exist.
+
+  ## Examples
+
+      iex> get_worst_word!(123)
+      %WorstWord{}
+
+      iex> get_worst_word!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_worst_word!(id), do: Repo.get!(WorstWord, id)
+
+  @doc """
+  Creates a worst_word.
+
+  ## Examples
+
+      iex> create_worst_word(%{field: value})
+      {:ok, %WorstWord{}}
+
+      iex> create_worst_word(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_worst_word(attrs \\ %{}) do
+    %WorstWord{}
+    |> WorstWord.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a worst_word.
+
+  ## Examples
+
+      iex> update_worst_word(worst_word, %{field: new_value})
+      {:ok, %WorstWord{}}
+
+      iex> update_worst_word(worst_word, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_worst_word(%WorstWord{} = worst_word, attrs) do
+    worst_word
+    |> WorstWord.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a worst_word.
+
+  ## Examples
+
+      iex> delete_worst_word(worst_word)
+      {:ok, %WorstWord{}}
+
+      iex> delete_worst_word(worst_word)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_worst_word(%WorstWord{} = worst_word) do
+    Repo.delete(worst_word)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking worst_word changes.
+
+  ## Examples
+
+      iex> change_worst_word(worst_word)
+      %Ecto.Changeset{data: %WorstWord{}}
+
+  """
+  def change_worst_word(%WorstWord{} = worst_word, attrs \\ %{}) do
+    WorstWord.changeset(worst_word, attrs)
+  end
+end

--- a/lib/better_words/words/worst_word.ex
+++ b/lib/better_words/words/worst_word.ex
@@ -1,0 +1,18 @@
+defmodule BetterWords.Words.WorstWord do
+  use BetterWords.Schema
+
+  schema "worst_words" do
+    field :label, :string
+    field :reason, :string
+    field :user_id, Ecto.UUID
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(worst_word, attrs) do
+    worst_word
+    |> cast(attrs, [:label, :user_id, :reason])
+    |> validate_required([:label, :user_id, :reason])
+  end
+end

--- a/lib/better_words_web.ex
+++ b/lib/better_words_web.ex
@@ -91,6 +91,7 @@ defmodule BetterWordsWeb do
 
       # Import LiveView and .heex helpers (live_render, live_patch, <.form>, etc)
       import Phoenix.LiveView.Helpers
+      import BetterWordsWeb.LiveHelpers
 
       # Import basic rendering functionality (render, render_layout, etc)
       import Phoenix.View

--- a/lib/better_words_web/live/live_helpers.ex
+++ b/lib/better_words_web/live/live_helpers.ex
@@ -1,0 +1,60 @@
+defmodule BetterWordsWeb.LiveHelpers do
+  import Phoenix.LiveView
+  import Phoenix.LiveView.Helpers
+
+  alias Phoenix.LiveView.JS
+
+  @doc """
+  Renders a live component inside a modal.
+
+  The rendered modal receives a `:return_to` option to properly update
+  the URL when the modal is closed.
+
+  ## Examples
+
+      <.modal return_to={Routes.worst_word_index_path(@socket, :index)}>
+        <.live_component
+          module={BetterWordsWeb.WorstWordLive.FormComponent}
+          id={@worst_word.id || :new}
+          title={@page_title}
+          action={@live_action}
+          return_to={Routes.worst_word_index_path(@socket, :index)}
+          worst_word: @worst_word
+        />
+      </.modal>
+  """
+  def modal(assigns) do
+    assigns = assign_new(assigns, :return_to, fn -> nil end)
+
+    ~H"""
+    <div id="modal" class="phx-modal fade-in" phx-remove={hide_modal()}>
+      <div
+        id="modal-content"
+        class="phx-modal-content fade-in-scale"
+        phx-click-away={JS.dispatch("click", to: "#close")}
+        phx-window-keydown={JS.dispatch("click", to: "#close")}
+        phx-key="escape"
+      >
+        <%= if @return_to do %>
+          <%= live_patch "✖",
+            to: @return_to,
+            id: "close",
+            class: "phx-modal-close",
+            phx_click: hide_modal()
+          %>
+        <% else %>
+         <a id="close" href="#" class="phx-modal-close" phx-click={hide_modal()}>✖</a>
+        <% end %>
+
+        <%= render_slot(@inner_block) %>
+      </div>
+    </div>
+    """
+  end
+
+  defp hide_modal(js \\ %JS{}) do
+    js
+    |> JS.hide(to: "#modal", transition: "fade-out")
+    |> JS.hide(to: "#modal-content", transition: "fade-out-scale")
+  end
+end

--- a/lib/better_words_web/live/worst_word_live/form_component.ex
+++ b/lib/better_words_web/live/worst_word_live/form_component.ex
@@ -1,0 +1,55 @@
+defmodule BetterWordsWeb.WorstWordLive.FormComponent do
+  use BetterWordsWeb, :live_component
+
+  alias BetterWords.Words
+
+  @impl true
+  def update(%{worst_word: worst_word} = assigns, socket) do
+    changeset = Words.change_worst_word(worst_word)
+
+    {:ok,
+     socket
+     |> assign(assigns)
+     |> assign(:changeset, changeset)}
+  end
+
+  @impl true
+  def handle_event("validate", %{"worst_word" => worst_word_params}, socket) do
+    changeset =
+      socket.assigns.worst_word
+      |> Words.change_worst_word(worst_word_params)
+      |> Map.put(:action, :validate)
+
+    {:noreply, assign(socket, :changeset, changeset)}
+  end
+
+  def handle_event("save", %{"worst_word" => worst_word_params}, socket) do
+    save_worst_word(socket, socket.assigns.action, worst_word_params)
+  end
+
+  defp save_worst_word(socket, :edit, worst_word_params) do
+    case Words.update_worst_word(socket.assigns.worst_word, worst_word_params) do
+      {:ok, _worst_word} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "Worst word updated successfully")
+         |> push_redirect(to: socket.assigns.return_to)}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign(socket, :changeset, changeset)}
+    end
+  end
+
+  defp save_worst_word(socket, :new, worst_word_params) do
+    case Words.create_worst_word(worst_word_params) do
+      {:ok, _worst_word} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "Worst word created successfully")
+         |> push_redirect(to: socket.assigns.return_to)}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign(socket, changeset: changeset)}
+    end
+  end
+end

--- a/lib/better_words_web/live/worst_word_live/form_component.html.heex
+++ b/lib/better_words_web/live/worst_word_live/form_component.html.heex
@@ -1,0 +1,28 @@
+<div>
+  <h2><%= @title %></h2>
+
+  <.form
+    let={f}
+    for={@changeset}
+    id="worst_word-form"
+    phx-target={@myself}
+    phx-change="validate"
+    phx-submit="save">
+  
+    <%= label f, :label %>
+    <%= text_input f, :label %>
+    <%= error_tag f, :label %>
+  
+    <%= label f, :user_id %>
+    <%= text_input f, :user_id %>
+    <%= error_tag f, :user_id %>
+  
+    <%= label f, :reason %>
+    <%= textarea f, :reason %>
+    <%= error_tag f, :reason %>
+  
+    <div>
+      <%= submit "Save", phx_disable_with: "Saving..." %>
+    </div>
+  </.form>
+</div>

--- a/lib/better_words_web/live/worst_word_live/index.ex
+++ b/lib/better_words_web/live/worst_word_live/index.ex
@@ -1,0 +1,51 @@
+defmodule BetterWordsWeb.WorstWordLive.Index do
+  use BetterWordsWeb, :live_view
+
+  alias BetterWords.Words
+  alias BetterWords.Words.WorstWord
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok, assign(socket, :worst_words, list_worst_words())}
+  end
+
+  @impl true
+  def handle_params(params, _url, socket) do
+    {:noreply, apply_action(socket, socket.assigns.live_action, params)}
+  end
+
+  defp apply_action(socket, :edit, %{"id" => id}) do
+    socket
+    |> assign(:page_title, "Edit Worst word")
+    |> assign(:worst_word, Words.get_worst_word!(id))
+  end
+
+  defp apply_action(socket, :new, _params) do
+    socket
+    |> assign(:page_title, "New Worst word")
+    |> assign(:worst_word, %WorstWord{})
+  end
+
+  defp apply_action(socket, :index, _params) do
+    socket
+    |> assign(:page_title, "Listing Worst words")
+    |> assign(:worst_word, nil)
+  end
+
+  @impl true
+  def handle_event("delete", %{"id" => id}, socket) do
+    worst_word = Words.get_worst_word!(id)
+    {:ok, _} = Words.delete_worst_word(worst_word)
+
+    {:noreply, assign(socket, :worst_words, list_worst_words())}
+  end
+
+  def handle_event("random_number", _params, socket) do
+    random_number = Enum.random(1..100)
+    {:noreply, assign(socket, :random_number, random_number)}
+  end
+
+  defp list_worst_words do
+    Words.list_worst_words()
+  end
+end

--- a/lib/better_words_web/live/worst_word_live/index.html.heex
+++ b/lib/better_words_web/live/worst_word_live/index.html.heex
@@ -1,0 +1,43 @@
+<h1>Listing Worst words</h1>
+
+<%= if @live_action in [:new, :edit] do %>
+  <.modal return_to={Routes.worst_word_index_path(@socket, :index)}>
+    <.live_component
+      module={BetterWordsWeb.WorstWordLive.FormComponent}
+      id={@worst_word.id || :new}
+      title={@page_title}
+      action={@live_action}
+      worst_word={@worst_word}
+      return_to={Routes.worst_word_index_path(@socket, :index)}
+    />
+  </.modal>
+<% end %>
+
+<table>
+  <thead>
+    <tr>
+      <th>Label</th>
+      <th>User</th>
+      <th>Reason</th>
+
+      <th></th>
+    </tr>
+  </thead>
+  <tbody id="worst_words">
+    <%= for worst_word <- @worst_words do %>
+      <tr id={"worst_word-#{worst_word.id}"}>
+        <td><%= worst_word.label %></td>
+        <td><%= worst_word.user_id %></td>
+        <td><%= worst_word.reason %></td>
+
+        <td>
+          <span><%= live_redirect "Show", to: Routes.worst_word_show_path(@socket, :show, worst_word) %></span>
+          <span><%= live_patch "Edit", to: Routes.worst_word_index_path(@socket, :edit, worst_word) %></span>
+          <span><%= link "Delete", to: "#", phx_click: "delete", phx_value_id: worst_word.id, data: [confirm: "Are you sure?"] %></span>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<span><%= live_patch "New Worst word", to: Routes.worst_word_index_path(@socket, :new) %></span>

--- a/lib/better_words_web/live/worst_word_live/show.ex
+++ b/lib/better_words_web/live/worst_word_live/show.ex
@@ -1,0 +1,21 @@
+defmodule BetterWordsWeb.WorstWordLive.Show do
+  use BetterWordsWeb, :live_view
+
+  alias BetterWords.Words
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_params(%{"id" => id}, _, socket) do
+    {:noreply,
+     socket
+     |> assign(:page_title, page_title(socket.assigns.live_action))
+     |> assign(:worst_word, Words.get_worst_word!(id))}
+  end
+
+  defp page_title(:show), do: "Show Worst word"
+  defp page_title(:edit), do: "Edit Worst word"
+end

--- a/lib/better_words_web/live/worst_word_live/show.html.heex
+++ b/lib/better_words_web/live/worst_word_live/show.html.heex
@@ -1,0 +1,36 @@
+<h1>Show Worst word</h1>
+
+<%= if @live_action in [:edit] do %>
+  <.modal return_to={Routes.worst_word_show_path(@socket, :show, @worst_word)}>
+    <.live_component
+      module={BetterWordsWeb.WorstWordLive.FormComponent}
+      id={@worst_word.id}
+      title={@page_title}
+      action={@live_action}
+      worst_word={@worst_word}
+      return_to={Routes.worst_word_show_path(@socket, :show, @worst_word)}
+    />
+  </.modal>
+<% end %>
+
+<ul>
+
+  <li>
+    <strong>Label:</strong>
+    <%= @worst_word.label %>
+  </li>
+
+  <li>
+    <strong>User:</strong>
+    <%= @worst_word.user_id %>
+  </li>
+
+  <li>
+    <strong>Reason:</strong>
+    <%= @worst_word.reason %>
+  </li>
+
+</ul>
+
+<span><%= live_patch "Edit", to: Routes.worst_word_show_path(@socket, :edit, @worst_word), class: "button" %></span> |
+<span><%= live_redirect "Back", to: Routes.worst_word_index_path(@socket, :index) %></span>

--- a/lib/better_words_web/router.ex
+++ b/lib/better_words_web/router.ex
@@ -18,6 +18,13 @@ defmodule BetterWordsWeb.Router do
     pipe_through :browser
 
     get "/", PageController, :index
+
+    live "/worst_words", WorstWordLive.Index, :index
+    live "/worst_words/new", WorstWordLive.Index, :new
+    live "/worst_words/:id/edit", WorstWordLive.Index, :edit
+
+    live "/worst_words/:id", WorstWordLive.Show, :show
+    live "/worst_words/:id/show/edit", WorstWordLive.Show, :edit
   end
 
   # Other scopes may use custom stacks.

--- a/priv/repo/migrations/20220407225616_create_worst_words.exs
+++ b/priv/repo/migrations/20220407225616_create_worst_words.exs
@@ -1,0 +1,14 @@
+defmodule BetterWords.Repo.Migrations.CreateWorstWords do
+  use Ecto.Migration
+
+  def change do
+    create table(:worst_words, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :label, :string
+      add :user_id, :uuid
+      add :reason, :text
+
+      timestamps()
+    end
+  end
+end

--- a/test/better_words/words_test.exs
+++ b/test/better_words/words_test.exs
@@ -1,0 +1,63 @@
+defmodule BetterWords.WordsTest do
+  use BetterWords.DataCase
+
+  alias BetterWords.Words
+
+  describe "worst_words" do
+    alias BetterWords.Words.WorstWord
+
+    import BetterWords.WordsFixtures
+
+    @invalid_attrs %{label: nil, reason: nil, user_id: nil}
+
+    test "list_worst_words/0 returns all worst_words" do
+      worst_word = worst_word_fixture()
+      assert Words.list_worst_words() == [worst_word]
+    end
+
+    test "get_worst_word!/1 returns the worst_word with given id" do
+      worst_word = worst_word_fixture()
+      assert Words.get_worst_word!(worst_word.id) == worst_word
+    end
+
+    test "create_worst_word/1 with valid data creates a worst_word" do
+      valid_attrs = %{label: "some label", reason: "some reason", user_id: "7488a646-e31f-11e4-aace-600308960662"}
+
+      assert {:ok, %WorstWord{} = worst_word} = Words.create_worst_word(valid_attrs)
+      assert worst_word.label == "some label"
+      assert worst_word.reason == "some reason"
+      assert worst_word.user_id == "7488a646-e31f-11e4-aace-600308960662"
+    end
+
+    test "create_worst_word/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Words.create_worst_word(@invalid_attrs)
+    end
+
+    test "update_worst_word/2 with valid data updates the worst_word" do
+      worst_word = worst_word_fixture()
+      update_attrs = %{label: "some updated label", reason: "some updated reason", user_id: "7488a646-e31f-11e4-aace-600308960668"}
+
+      assert {:ok, %WorstWord{} = worst_word} = Words.update_worst_word(worst_word, update_attrs)
+      assert worst_word.label == "some updated label"
+      assert worst_word.reason == "some updated reason"
+      assert worst_word.user_id == "7488a646-e31f-11e4-aace-600308960668"
+    end
+
+    test "update_worst_word/2 with invalid data returns error changeset" do
+      worst_word = worst_word_fixture()
+      assert {:error, %Ecto.Changeset{}} = Words.update_worst_word(worst_word, @invalid_attrs)
+      assert worst_word == Words.get_worst_word!(worst_word.id)
+    end
+
+    test "delete_worst_word/1 deletes the worst_word" do
+      worst_word = worst_word_fixture()
+      assert {:ok, %WorstWord{}} = Words.delete_worst_word(worst_word)
+      assert_raise Ecto.NoResultsError, fn -> Words.get_worst_word!(worst_word.id) end
+    end
+
+    test "change_worst_word/1 returns a worst_word changeset" do
+      worst_word = worst_word_fixture()
+      assert %Ecto.Changeset{} = Words.change_worst_word(worst_word)
+    end
+  end
+end

--- a/test/better_words_web/live/worst_word_live_test.exs
+++ b/test/better_words_web/live/worst_word_live_test.exs
@@ -1,0 +1,110 @@
+defmodule BetterWordsWeb.WorstWordLiveTest do
+  use BetterWordsWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+  import BetterWords.WordsFixtures
+
+  @create_attrs %{label: "some label", reason: "some reason", user_id: "7488a646-e31f-11e4-aace-600308960662"}
+  @update_attrs %{label: "some updated label", reason: "some updated reason", user_id: "7488a646-e31f-11e4-aace-600308960668"}
+  @invalid_attrs %{label: nil, reason: nil, user_id: nil}
+
+  defp create_worst_word(_) do
+    worst_word = worst_word_fixture()
+    %{worst_word: worst_word}
+  end
+
+  describe "Index" do
+    setup [:create_worst_word]
+
+    test "lists all worst_words", %{conn: conn, worst_word: worst_word} do
+      {:ok, _index_live, html} = live(conn, Routes.worst_word_index_path(conn, :index))
+
+      assert html =~ "Listing Worst words"
+      assert html =~ worst_word.label
+    end
+
+    test "saves new worst_word", %{conn: conn} do
+      {:ok, index_live, _html} = live(conn, Routes.worst_word_index_path(conn, :index))
+
+      assert index_live |> element("a", "New Worst word") |> render_click() =~
+               "New Worst word"
+
+      assert_patch(index_live, Routes.worst_word_index_path(conn, :new))
+
+      assert index_live
+             |> form("#worst_word-form", worst_word: @invalid_attrs)
+             |> render_change() =~ "can&#39;t be blank"
+
+      {:ok, _, html} =
+        index_live
+        |> form("#worst_word-form", worst_word: @create_attrs)
+        |> render_submit()
+        |> follow_redirect(conn, Routes.worst_word_index_path(conn, :index))
+
+      assert html =~ "Worst word created successfully"
+      assert html =~ "some label"
+    end
+
+    test "updates worst_word in listing", %{conn: conn, worst_word: worst_word} do
+      {:ok, index_live, _html} = live(conn, Routes.worst_word_index_path(conn, :index))
+
+      assert index_live |> element("#worst_word-#{worst_word.id} a", "Edit") |> render_click() =~
+               "Edit Worst word"
+
+      assert_patch(index_live, Routes.worst_word_index_path(conn, :edit, worst_word))
+
+      assert index_live
+             |> form("#worst_word-form", worst_word: @invalid_attrs)
+             |> render_change() =~ "can&#39;t be blank"
+
+      {:ok, _, html} =
+        index_live
+        |> form("#worst_word-form", worst_word: @update_attrs)
+        |> render_submit()
+        |> follow_redirect(conn, Routes.worst_word_index_path(conn, :index))
+
+      assert html =~ "Worst word updated successfully"
+      assert html =~ "some updated label"
+    end
+
+    test "deletes worst_word in listing", %{conn: conn, worst_word: worst_word} do
+      {:ok, index_live, _html} = live(conn, Routes.worst_word_index_path(conn, :index))
+
+      assert index_live |> element("#worst_word-#{worst_word.id} a", "Delete") |> render_click()
+      refute has_element?(index_live, "#worst_word-#{worst_word.id}")
+    end
+  end
+
+  describe "Show" do
+    setup [:create_worst_word]
+
+    test "displays worst_word", %{conn: conn, worst_word: worst_word} do
+      {:ok, _show_live, html} = live(conn, Routes.worst_word_show_path(conn, :show, worst_word))
+
+      assert html =~ "Show Worst word"
+      assert html =~ worst_word.label
+    end
+
+    test "updates worst_word within modal", %{conn: conn, worst_word: worst_word} do
+      {:ok, show_live, _html} = live(conn, Routes.worst_word_show_path(conn, :show, worst_word))
+
+      assert show_live |> element("a", "Edit") |> render_click() =~
+               "Edit Worst word"
+
+      assert_patch(show_live, Routes.worst_word_show_path(conn, :edit, worst_word))
+
+      assert show_live
+             |> form("#worst_word-form", worst_word: @invalid_attrs)
+             |> render_change() =~ "can&#39;t be blank"
+
+      {:ok, _, html} =
+        show_live
+        |> form("#worst_word-form", worst_word: @update_attrs)
+        |> render_submit()
+        |> follow_redirect(conn, Routes.worst_word_show_path(conn, :show, worst_word))
+
+      assert html =~ "Worst word updated successfully"
+      assert html =~ "some updated label"
+    end
+  end
+end

--- a/test/support/fixtures/words_fixtures.ex
+++ b/test/support/fixtures/words_fixtures.ex
@@ -1,0 +1,22 @@
+defmodule BetterWords.WordsFixtures do
+  @moduledoc """
+  This module defines test helpers for creating
+  entities via the `BetterWords.Words` context.
+  """
+
+  @doc """
+  Generate a worst_word.
+  """
+  def worst_word_fixture(attrs \\ %{}) do
+    {:ok, worst_word} =
+      attrs
+      |> Enum.into(%{
+        label: "some label",
+        reason: "some reason",
+        user_id: "7488a646-e31f-11e4-aace-600308960662"
+      })
+      |> BetterWords.Words.create_worst_word()
+
+    worst_word
+  end
+end


### PR DESCRIPTION
![american sign language for generator](https://media.giphy.com/media/l0MYwrucQ9amOkFHO/giphy.gif)

This PR is the result of our last work session. We used a generator to create our first resource and walked through the generated code.

The generator line was:
```
mix phx.gen.live Words WorstWord worst_words label:string user_id:uuid reason:text
```

This created a **context** called `Words` and a resource (database table and matching Ecto.Schema file) called `WorstWords`.

The docs for the Phoenix generator that we used is [here](https://hexdocs.pm/phoenix/Mix.Tasks.Phx.Gen.Live.html).

I've annotated this PR to try to give context to all of the new code.